### PR TITLE
Introduce host star priors, based on 5D+RV Gaia statistics (incl. covariance)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,7 @@ eDR3 Distance prior summary file from this [source](https://arxiv.org/pdf/2012.0
 Current example (HD131399Ab) uses data from Wagner+22 and Nielsen+17. Thank you to Kevin Wagner for providing the latest astrometry!
 
 Log-likelihood and some utility functions borrowed heavily from `orbitize!` (BSD 3-clause).
+PPF of multivariate normal borrowed from `pints' (BSD 3-clause).
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ eDR3 Distance prior summary file from this [source](https://arxiv.org/pdf/2012.0
 Current example (HD131399Ab) uses data from Wagner+22 and Nielsen+17. Thank you to Kevin Wagner for providing the latest astrometry!
 
 Log-likelihood and some utility functions borrowed heavily from `orbitize!` (BSD 3-clause).
-PPF of multivariate normal borrowed from `pints' (BSD 3-clause).
+PPF of multivariate normal borrowed from `pints` (BSD 3-clause).
 
 Installation
 ============

--- a/backtracks/backtracks.py
+++ b/backtracks/backtracks.py
@@ -510,7 +510,7 @@ class System():
 
         # Compute median, and 16th and 84th percentiles
         self.run_median = np.median(samples, axis=0)
-        self.run_quant = np.quantile(samples, [0.16, 0.84], axis=0)
+        self.run_quant = np.quantile(samples, [0.1587, 0.8413], axis=0)
 
         return self.results
 

--- a/backtracks/plotting.py
+++ b/backtracks/plotting.py
@@ -74,7 +74,7 @@ def posterior(backtracks, fileprefix='./', filepost='.pdf'):
                                # label_kwargs={},
                                show_titles=True,
                                title_kwargs={'fontsize':14}
-                               # quantiles=None,
+                               quantiles=(0.1587,0.5,0.8413),
                                # fig=(fig, axes[:, 4:])
                               )
     fig.figsize = (9,9)

--- a/backtracks/plotting.py
+++ b/backtracks/plotting.py
@@ -65,6 +65,7 @@ def posterior(backtracks, fileprefix='./', filepost='.pdf'):
     # plot extended run (right)
     fig, ax = dyplot.cornerplot(backtracks.results,
                                color='cornflowerblue',
+                               dims=range(5),
                                # truths=np.zeros(ndim),
                                # span=[(-4.5, 4.5) for i in range(ndim)],
                                labels=labels,
@@ -134,7 +135,7 @@ def trackplot(
 
     if plot_stationary:
         stat_pars = backtracks.run_median.copy()
-        stat_pars[2:] = 0.0
+        stat_pars[2:5] = 0.0
 
         ra_stat, dec_stat = backtracks.radecdists(plot_epochs_tt, stat_pars)
         axs['A'].plot(ra_stat, dec_stat, color="lightgray", label="stationary background", ls='--')
@@ -317,7 +318,7 @@ def neighborhood(backtracks, fileprefix='./', filepost='.pdf'):
     nearby_table['pmdec'] = backtracks.nearby['pmdec'].data
     nearby_table['parallax'] = backtracks.nearby['parallax'].data
 
-    truths = backtracks.run_median[2:]
+    truths = backtracks.run_median[2:5]
 
     # 1,2,3 sigma levels for a 2d gaussian
     levels = 1.0 - np.exp(-0.5 * np.arange(1, 3.1, 1) ** 2)
@@ -362,7 +363,7 @@ def stationtrackplot(backtracks, ref_epoch, daysback=2600, daysforward=1200, fil
     corr_terms=~np.isnan(backtracks.rho) # corr_terms is everywhere where rho is not a nan.
 
     # plot stationary bg track at infinity (0 parallax)
-    rasbg,decbg = backtracks.radecdists(plot_epochs_tt, best_pars[0],best_pars[1],0,0,0) # retrieve coordinates at full range of epochs
+    rasbg,decbg = backtracks.radecdists(plot_epochs_tt, best_pars[0],best_pars[1],0,0,0,best_pars[5],best_pars[6],best_pars[7],best_pars[8],best_pars[9],best_pars[10]) # retrieve coordinates at full range of epochs
     # rasbg,decbg = backtracks.radecdists(plot_epochs_tt, backtracks.ra0, backtracks.dec0, 0,0,0) # retrieve coordinates at full range of epochs
 
     axs['B'].plot(plot_times.decimalyear,radec2seppa(rasbg,decbg)[0],color='gray',alpha=1, zorder=3,ls='--')

--- a/backtracks/plotting.py
+++ b/backtracks/plotting.py
@@ -73,8 +73,9 @@ def posterior(backtracks, fileprefix='./', filepost='.pdf'):
                                max_n_ticks=4,
                                # label_kwargs={},
                                show_titles=True,
-                               title_kwargs={'fontsize':14}
+                               title_kwargs={'fontsize':14},
                                quantiles=(0.1587,0.5,0.8413),
+                               title_quantiles=(0.1587,0.5,0.8413)
                                # fig=(fig, axes[:, 4:])
                               )
     fig.figsize = (9,9)

--- a/backtracks/utils.py
+++ b/backtracks/utils.py
@@ -107,3 +107,52 @@ def transform_gengamm(x, L=1.35e3, alpha=1, beta=2):
 def utc2tt(jd_utc):
     return Time(jd_utc,scale="utc",format="jd").tt.jd
 
+class HostStarPriors(): # stripped version from pints (MultivariateGaussianLogPrior from https://github.com/pints-team/pints/blob/main/pints/_log_priors.py), BSD3-clause
+    
+    def __init__(self, mean, cov): # setting up distribution, this is done only once so we dont have to bother with a fast Cholesky inversion. Host star parameter distribution doesnt change.
+        self._mean = mean
+        self._cov = cov
+        self._n_parameters = mean.shape[0]
+        
+        self._sigma12_sigma22_inv_l = []
+        self._sigma_bar_l = []
+        self._mu1 = []
+        self._mu2 = []
+        
+        for j in range(1, self._n_parameters):
+            sigma = self._cov[0:(j + 1), 0:(j + 1)]
+            dims = sigma.shape
+            sigma11 = sigma[dims[0] - 1, dims[1] - 1]
+            sigma22 = sigma[0:(dims[0] - 1), 0:(dims[0] - 1)]
+            sigma12 = sigma[dims[0] - 1, 0:(dims[0] - 1)]
+            sigma21 = sigma[0:(dims[0] - 1), dims[0] - 1]
+            mean = self._mean[0:dims[0]]
+            mu2 = mean[0:(dims[0] - 1)]
+            mu1 = mean[dims[0] - 1]
+            sigma12_sigma22_inv = np.matmul(sigma12,
+                                            np.linalg.inv(sigma22))
+            sigma_bar = np.sqrt(sigma11 - np.matmul(sigma12_sigma22_inv,
+                                                    sigma21))
+            self._sigma12_sigma22_inv_l.append(sigma12_sigma22_inv)
+            self._sigma_bar_l.append(sigma_bar)
+            self._mu1.append(mu1)
+            self._mu2.append(mu2)
+   
+    def transform_normal_multivariate(self, ps): # pulling from distribution with random number between 0 and 1
+        
+        n_samples = ps.shape[0]
+        n_params = ps.shape[1]
+        
+        icdfs = np.zeros((n_samples, n_params))
+        for j in range(n_samples):
+            for i in range(self._n_parameters):
+                if i == 0: # the first axis just takes the default mean and sigma and draws with a ppf
+                    mu = self._mean[0]
+                    sigma = np.sqrt(self._cov[0, 0])
+                else: # the next axis needs to bias the mean and sigma of the ppf based on the previously drawn numbers
+                    sigma = self._sigma_bar_l[i - 1]
+                    mu = self._mu1[i - 1] + np.matmul(
+                        self._sigma12_sigma22_inv_l[i - 1],
+                        (np.array(icdfs[j, 0:i]) - self._mu2[i - 1]))
+                icdfs[j, i] = norm.ppf(ps[j, i], mu, sigma) 
+        return icdfs

--- a/backtracks/utils.py
+++ b/backtracks/utils.py
@@ -155,4 +155,4 @@ class HostStarPriors(): # stripped version from pints (MultivariateGaussianLogPr
                         self._sigma12_sigma22_inv_l[i - 1],
                         (np.array(icdfs[j, 0:i]) - self._mu2[i - 1]))
                 icdfs[j, i] = norm.ppf(ps[j, i], mu, sigma) 
-        return icdfs
+        return np.squeeze(np.array_split(icdfs,n_params,axis=1))


### PR DESCRIPTION
Closes #35. 

Potentially could use another diagnostic plot where host star parameters are compared with the prior to make sure it is consistent. 

Might crash if Gaia has no RV datapoint.